### PR TITLE
Name conflicts and type mismatch errors

### DIFF
--- a/pv/tls-lib-draft20.pvl
+++ b/pv/tls-lib-draft20.pvl
@@ -152,7 +152,7 @@ event WeakOrCompromisedKey(pubkey).
 event CompromisedPreSharedKey(preSharedKey).
 event PostSessionCompromisedKey(pubkey).
 
-let longTermKeys() = 
+let longTermKeysProc() = 
     event WeakOrCompromisedKey(NoPubKey)
  |  (in(io,a:prin);
      new k:privkey; 

--- a/pv/tls-lib.pvl
+++ b/pv/tls-lib.pvl
@@ -152,7 +152,7 @@ event WeakOrCompromisedKey(pubkey).
 event CompromisedPreSharedKey(preSharedKey).
 event PostSessionCompromisedKey(pubkey).
 
-let longTermKeys() = 
+let longTermKeysProc() = 
     event WeakOrCompromisedKey(NoPubKey)
  |  (in(io,a:prin);
      new k:privkey; 

--- a/pv/tls12-tls13-draft18.pv
+++ b/pv/tls12-tls13-draft18.pv
@@ -94,7 +94,7 @@ query cr:random, sr:random, psk:preSharedKey, p:pubkey, e:element,  ms:bitstring
       event(ServerChoosesKEX(cr',sr',p,TLS12,RSA(WeakRSADecryption)))  ||  
       event(ServerChoosesHash(cr',sr',p,TLS13,WeakHash)). 
 
-query cr:random, psk:bitstring,kex:kex_alg,h:hash_alg,kc0:ae_key,ems0:bitstring,pt:psk_type;
+query cr:random, psk:preSharedKey,kex:kex_alg,h:hash_alg,kc0:ae_key,ems0:bitstring,pt:psk_type;
       attacker(m_c0(TLS13,cr,psk)) ==>
       (psk = NoPSK || event(CompromisedPreSharedKey(psk))) ||
       event(ClientOffersAE(cr,WeakAE)).
@@ -133,6 +133,6 @@ query cr:random, sr:random, cr':random, sr':random, psk:preSharedKey, e:element,
 process (
 	 !Client13() | !Server13() | 
 	 !Client12() | !Server12() | 
-	 !longTermKeys() | !appData() |
+	 !longTermKeysProc() | !appData() |
 	 !secrecyQuery() | !channelBindingQuery() )
 

--- a/pv/tls12.pv
+++ b/pv/tls12.pv
@@ -141,5 +141,5 @@ query cr:random, sr:random, psk:preSharedKey,
         
 process 
 	!Client12() | !Server12() | 
-	!longTermKeys() | !appData() |
+	!longTermKeysProc() | !appData() |
 	!secrecyQuery() | !channelBindingQuery()

--- a/pv/tls13-draft18-only.pv
+++ b/pv/tls13-draft18-only.pv
@@ -90,7 +90,7 @@ query cr:random, sr:random, psk:preSharedKey, p:pubkey, e:element,  ms:bitstring
       event(ServerChoosesKEX(cr,sr,p,TLS13,DHE_13(WeakDH,e))) ||     
       event(ServerChoosesHash(cr',sr',p,TLS13,WeakHash)). 
 
-query cr:nonce, psk:bitstring,kex:kex_alg,h:hash_alg,kc0:ae_key,ems0:bitstring,pt:psk_type;
+query cr:random, psk:preSharedKey,kex:kex_alg,h:hash_alg,kc0:ae_key,ems0:bitstring,pt:psk_type;
       attacker(m_c0(TLS13,cr,psk)) ==>
       (psk = NoPSK || event(CompromisedPreSharedKey(psk))) ||
       event(ClientOffersAE(cr,WeakAE)).
@@ -128,6 +128,6 @@ query cr:random, sr:random, cr':random, sr':random, psk:preSharedKey, e:element,
 
 process (
 	 !Client13() | !Server13() | 
-	 !longTermKeys() | !appData() |
+	 !longTermKeysProc() | !appData() |
 	 !secrecyQuery() | !channelBindingQuery() )
 

--- a/pv/tls13-draft20-only.pv
+++ b/pv/tls13-draft20-only.pv
@@ -90,7 +90,7 @@ query cr:random, sr:random, psk:preSharedKey, p:pubkey, e:element,  ms:bitstring
       event(ServerChoosesKEX(cr,sr,p,TLS13,DHE_13(WeakDH,e))) ||     
       event(ServerChoosesHash(cr',sr',p,TLS13,WeakHash)). 
 
-query cr:nonce, psk:bitstring,kex:kex_alg,h:hash_alg,kc0:ae_key,ems0:bitstring,pt:psk_type;
+query cr:random, psk:preSharedKey,kex:kex_alg,h:hash_alg,kc0:ae_key,ems0:bitstring,pt:psk_type;
       attacker(m_c0(TLS13,cr,psk)) ==>
       (psk = NoPSK || event(CompromisedPreSharedKey(psk))) ||
       event(ClientOffersAE(cr,WeakAE)).
@@ -128,6 +128,6 @@ query cr:random, sr:random, cr':random, sr':random, psk:preSharedKey, e:element,
 
 process (
 	 !Client13() | !Server13() | 
-	 !longTermKeys() | !appData() |
+	 !longTermKeysProc() | !appData() |
 	 !secrecyQuery() | !channelBindingQuery() )
 


### PR DESCRIPTION
Fixed the name conflicts errors, for example, the identifier `longTermKeys` used for both table as well as for a process. I also fixed type mismatch errors such as `bitstring` used for `preSharedKey` and so forth.